### PR TITLE
Add pages to search results

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -69,3 +69,10 @@ add_filter( 'excerpt_length', function ( $length ) {
     }
     return $length;
 }, 999 );
+
+// Include pages in search results alongside blog posts
+add_filter( 'pre_get_posts', function ( $query ) {
+    if ( ! is_admin() && $query->is_main_query() && $query->is_search() ) {
+        $query->set( 'post_type', [ 'post', 'page' ] );
+    }
+} );


### PR DESCRIPTION
## Summary
- include pages in the search query with blog posts

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7f073e7c8322b4ee2f99e0721e06