### PR TITLE
Improve sign‑up page styling

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -33,3 +33,43 @@
   margin-inline: auto;
   line-height: 1.7;
 }
+
+/* Signup Page */
+.signup-page {
+  padding: 4rem 1rem;
+  max-width: 600px;
+  margin-inline: auto;
+}
+
+.signup-form {
+  background: #fff;
+  padding: 2rem;
+  border-radius: var(--np-radius);
+  box-shadow: var(--np-shadow);
+}
+
+.signup-form p {
+  margin-bottom: 1rem;
+}
+
+.signup-form label {
+  font-weight: 500;
+}
+
+.signup-form input[type="text"],
+.signup-form input[type="email"],
+.signup-form input[type="password"] {
+  width: 100%;
+  padding: .65rem 1rem;
+  border: 1px solid var(--np-gray);
+  border-radius: var(--np-radius);
+}
+
+.signup-form button.btn {
+  margin-top: .5rem;
+}
+
+.nep-errors p {
+  color: #c00;
+  margin: 0 0 1rem;
+}

--- a/join-template.php
+++ b/join-template.php
@@ -3,7 +3,7 @@
 
 get_header(); ?>
 
-<main id="nep-signup" style="max-width:500px;margin:0 auto;padding:3rem 1rem;">
+<main id="nep-signup" class="signup-page">
 
 <?php
 if ( is_user_logged_in() ) {
@@ -48,19 +48,19 @@ if ( is_user_logged_in() ) {
 		}
 
 		if ( $errors->get_error_messages() ) {
-			echo '<div class="nep-errors">';
-			foreach ( $errors->get_error_messages() as $e ) {
-				echo '<p style="color:#c00;">'. esc_html( $e ) .'</p>';
-			}
-			echo '</div>';
-		}
-	}
+                        echo '<div class="nep-errors">';
+                        foreach ( $errors->get_error_messages() as $e ) {
+                                echo '<p>'. esc_html( $e ) .'</p>';
+                        }
+                        echo '</div>';
+                }
+        }
 
 	/* ─── Show the form ──────────────────────────── */
 	?>
 	<h1>Create your NEPRENEUR account</h1>
 
-	<form method="post">
+        <form method="post" class="signup-form">
 		<p>
 			<label>Username<br>
 				<input type="text" name="username" required>
@@ -84,7 +84,7 @@ if ( is_user_logged_in() ) {
 
 		<?php wp_nonce_field( 'nep_reg', 'nep_reg_nonce' ); ?>
 
-		<p><button type="submit">Sign Up</button></p>
+                <p><button type="submit" class="btn">Sign Up</button></p>
 	</form>
 	<?php
 }


### PR DESCRIPTION
## Summary
- modernize `join-template.php` markup for sign-up page
- move inline styles to `pages.css`
- create `.signup-page` and `.signup-form` styles

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6870dc49cfa0832284a2be04021164f7