### PR TITLE
Enable comments on posts

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -68,3 +68,45 @@
 .pagination a:hover {
   background: var(--np-primary-light);
 }
+
+/* Comments */
+.comments-area {
+  margin-top: 3rem;
+}
+
+.comments-area .comment-list {
+  list-style: none;
+  padding: 0;
+}
+
+.comments-area .comment-list li {
+  margin-bottom: 2rem;
+  border-bottom: 1px solid #e0e7ef;
+  padding-bottom: 1rem;
+}
+
+.comments-area .comment-author .avatar {
+  border-radius: 50%;
+}
+
+.comment-form textarea,
+.comment-form input[type="text"],
+.comment-form input[type="email"] {
+  width: 100%;
+  padding: .6rem .8rem;
+  border: 1px solid #d1d5db;
+  border-radius: .5rem;
+}
+
+.comment-form input[type="submit"] {
+  background: var(--np-primary);
+  color: #fff;
+  border: none;
+  padding: .7rem 2rem;
+  border-radius: var(--np-radius);
+  cursor: pointer;
+}
+
+.comment-form input[type="submit"]:hover {
+  background: var(--np-primary-light);
+}

--- a/functions.php
+++ b/functions.php
@@ -9,6 +9,11 @@ add_action( 'wp_enqueue_scripts', function () {
 
     // smooth-scroll for anchor links
     wp_enqueue_script( 'nep-scroll', get_theme_file_uri( '/js/smooth-scroll.js' ), [], '1.0', true );
+
+    // allow threaded comment replies on singular posts
+    if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+        wp_enqueue_script( 'comment-reply' );
+    }
 } );
 
 // let WP know we’re using HTML5 & a custom title tag

--- a/single.php
+++ b/single.php
@@ -11,6 +11,13 @@
         </div>
       <?php endif; ?>
       <div><?php the_content(); ?></div>
+
+      <?php if ( comments_open() || get_comments_number() ) : ?>
+        <section class="comments-area">
+          <?php comments_template(); ?>
+        </section>
+      <?php endif; ?>
+
     </article>
   <?php endwhile; endif; ?>
   <p><a href="<?php echo esc_url( get_permalink( get_option( 'page_for_posts' ) ) ); ?>" class="btn">Back to Blog</a></p>


### PR DESCRIPTION
## Summary
- support threaded comments in script enqueue
- show comments on single post template
- style comments section

## Testing
- `php -l single.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_6872e38bb4348322a6755b58c4ac88a8