### PR TITLE
Add product archive template

### DIFF
--- a/archive-product.php
+++ b/archive-product.php
@@ -1,0 +1,29 @@
+<?php get_header(); ?>
+
+<section id="products">
+  <h2>Products</h2>
+  <div class="product-grid">
+    <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+      <article class="prod-card">
+        <?php if ( has_post_thumbnail() ) : ?>
+          <a href="<?php the_permalink(); ?>">
+            <?php the_post_thumbnail('medium'); ?>
+          </a>
+        <?php endif; ?>
+        <h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+        <?php if ( get_field('product_tagline') ) : ?>
+          <p><?php the_field('product_tagline'); ?></p>
+        <?php else : ?>
+          <p><?php echo wp_trim_words( get_the_content(), 15 ); ?></p>
+        <?php endif; ?>
+      </article>
+    <?php endwhile; else: ?>
+      <p>No products found.</p>
+    <?php endif; ?>
+  </div>
+  <nav class="pagination">
+    <?php the_posts_pagination(); ?>
+  </nav>
+</section>
+
+<?php get_footer(); ?>

--- a/header.php
+++ b/header.php
@@ -24,6 +24,7 @@
                 <li><a href="<?php echo esc_url( site_url('/get-started') ); ?>">Get Started</a></li>
                 <li><a href="<?php echo esc_url( site_url( '/forums' ) ); ?>">Forums</a></li>
                 <li><a href="<?php echo esc_url( site_url('/contact') ); ?>">Contact</a></li>
+                <li><a href="<?php echo esc_url( get_post_type_archive_link( 'product' ) ); ?>">Products</a></li>
                 <li><a href="<?php echo esc_url( get_post_type_archive_link( 'post' ) ); ?>">Blog</a></li>
             </ul>
         </nav>

--- a/style.css
+++ b/style.css
@@ -260,3 +260,8 @@ Version: 1.2
 .rel-card:hover{transform:translateY(-4px)}
 .rel-card h3{margin:.6rem 0 .3rem;font-size:1rem}
 .rel-card p{font-size:.85rem;color:var(--np-gray)}
+.product-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:1.2rem;margin-top:2rem}
+.prod-card{background:#fff;border-radius:12px;padding:1rem;text-align:center;box-shadow:0 1px 4px rgb(0 0 0/.06);transition:.2s}
+.prod-card:hover{transform:translateY(-4px)}
+.prod-card h3{margin:.6rem 0 .3rem;font-size:1rem}
+.prod-card p{font-size:.85rem;color:var(--np-gray)}


### PR DESCRIPTION
## Summary
- add a template for listing all products
- link to new Products archive in the navigation
- style product archive grid and cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872f8da24908322a8b52968916b8158