### PR TITLE
Add custom login page with rewrite rule

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -107,6 +107,7 @@ add_filter( 'pre_get_posts', function ( $query ) {
 require_once get_theme_file_path( '/inc/cpt-product.php' );
 require_once get_theme_file_path( '/inc/roles.php' );
 require_once get_theme_file_path( '/inc/rewrite-join.php' );
+require_once get_theme_file_path( '/inc/rewrite-login.php' );
 
 add_action('wp_ajax_np_upvote', 'np_upvote');
 add_action('wp_ajax_nopriv_np_upvote', 'np_upvote');

--- a/header.php
+++ b/header.php
@@ -26,6 +26,7 @@
                 <li><a href="<?php echo esc_url( site_url('/contact') ); ?>">Contact</a></li>
                 <li><a href="<?php echo esc_url( get_post_type_archive_link( 'product' ) ); ?>">Products</a></li>
                 <li><a href="<?php echo esc_url( get_post_type_archive_link( 'post' ) ); ?>">Blog</a></li>
+                <li><a href="<?php echo esc_url( site_url( '/login' ) ); ?>">Login</a></li>
             </ul>
         </nav>
 

--- a/inc/rewrite-login.php
+++ b/inc/rewrite-login.php
@@ -1,0 +1,14 @@
+<?php
+function nep_add_login_rewrite() {
+    add_rewrite_rule( '^login/?$', 'index.php?nep_login=1', 'top' );
+    add_rewrite_tag( '%nep_login%', '1' );
+}
+add_action( 'init', 'nep_add_login_rewrite' );
+
+function nep_load_login_template( $template ) {
+    if ( get_query_var( 'nep_login' ) ) {
+        return __DIR__ . '/../login-template.php';
+    }
+    return $template;
+}
+add_filter( 'template_include', 'nep_load_login_template' );

--- a/login-template.php
+++ b/login-template.php
@@ -1,0 +1,66 @@
+<?php
+/* Template: custom login (no plugins) */
+
+// -------------------------------------------------
+// Handle login before any HTML is sent
+// -------------------------------------------------
+$errors = new WP_Error();
+
+if ( isset( $_POST['nep_login_nonce'] ) && wp_verify_nonce( $_POST['nep_login_nonce'], 'nep_login' ) ) {
+    $creds = [
+        'user_login'    => sanitize_user( $_POST['username'] ),
+        'user_password' => $_POST['password'],
+        'remember'      => ! empty( $_POST['remember'] ),
+    ];
+    $user = wp_signon( $creds, false );
+    if ( ! is_wp_error( $user ) ) {
+        wp_set_current_user( $user->ID );
+        wp_set_auth_cookie( $user->ID );
+        wp_safe_redirect( home_url( '/forums/' ) );
+        exit;
+    } else {
+        $errors->add( 'invalid', 'Invalid username or password.' );
+    }
+}
+
+get_header(); ?>
+
+<section>
+<?php nep_breadcrumbs(); ?>
+<main id="nep-login" class="signup-page">
+<?php
+if ( is_user_logged_in() ) {
+    echo '<p>You\'re already signed in.</p>';
+} else {
+    if ( $errors->get_error_messages() ) {
+        echo '<div class="nep-errors">';
+        foreach ( $errors->get_error_messages() as $e ) {
+            echo '<p>' . esc_html( $e ) . '</p>';
+        }
+        echo '</div>';
+    }
+    ?>
+    <h1>Log In to NEPRENEUR</h1>
+
+    <form method="post" class="signup-form">
+        <div class="field">
+            <label for="username">Username</label>
+            <input id="username" type="text" name="username" required>
+        </div>
+        <div class="field">
+            <label for="password">Password</label>
+            <input id="password" type="password" name="password" required>
+        </div>
+        <div class="field">
+            <label><input type="checkbox" name="remember"> Remember me</label>
+        </div>
+        <?php wp_nonce_field( 'nep_login', 'nep_login_nonce' ); ?>
+        <button type="submit" class="btn">Log In</button>
+    </form>
+    <?php
+}
+?>
+</main>
+</section>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- create a login template that validates credentials and redirects on success
- add rewrite rules for `/login` requests
- expose the login page in the main navigation bar

## Testing
- `php -l login-template.php`
- `php -l inc/rewrite-login.php`
- `php -l functions.php`
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_688b23f90ee08322a9eee94f6ec4d534